### PR TITLE
Add patch for incorrect libevent version macro

### DIFF
--- a/patches/000-version-macro.patch
+++ b/patches/000-version-macro.patch
@@ -1,0 +1,24 @@
+diff -ru mysql-proxy-0.8.5.orig/src/chassis-mainloop.c mysql-proxy-0.8.5/src/chassis-mainloop.c
+--- mysql-proxy-0.8.5.orig/src/chassis-mainloop.c	2014-08-19 01:18:26.000000000 -0700
++++ mysql-proxy-0.8.5/src/chassis-mainloop.c	2018-02-14 16:46:14.170372045 -0800
+@@ -99,9 +99,9 @@
+ chassis *chassis_new() {
+ 	chassis *chas;
+ 
+-	if (0 != chassis_check_version(event_get_version(), _EVENT_VERSION)) {
++	if (0 != chassis_check_version(event_get_version(), LIBEVENT_VERSION)) {
+ 		g_critical("%s: chassis is build against libevent %s, but now runs against %s",
+-				G_STRLOC, _EVENT_VERSION, event_get_version());
++				G_STRLOC, LIBEVENT_VERSION, event_get_version());
+ 		return NULL;
+ 	}
+ 
+@@ -116,7 +116,7 @@
+ 
+ 	chas->threads = chassis_event_threads_new();
+ 
+-	chas->event_hdr_version = g_strdup(_EVENT_VERSION);
++	chas->event_hdr_version = g_strdup(LIBEVENT_VERSION);
+ 
+ 	chas->shutdown_hooks = chassis_shutdown_hooks_new();
+ 


### PR DESCRIPTION
Source should have been checking LIBEVENT_VERSION, but was
incorrectly checking _EVENT_VERSION.  This breaks against
more recent libevent releases.