### PR TITLE
Update for MariaDB 10.2.14

### DIFF
--- a/patches/001-flag-updates.patch
+++ b/patches/001-flag-updates.patch
@@ -1,0 +1,51 @@
+diff -ru mysql-proxy-0.8.5.orig/plugins/admin/admin-plugin.c mysql-proxy-0.8.5/plugins/admin/admin-plugin.c
+--- mysql-proxy-0.8.5.orig/plugins/admin/admin-plugin.c	2014-08-19 01:18:26.000000000 -0700
++++ mysql-proxy-0.8.5/plugins/admin/admin-plugin.c	2018-04-05 22:00:48.040345880 -0700
+@@ -208,7 +208,7 @@
+ 	challenge->server_version_str = g_strdup("5.0.99-agent-admin");
+ 	challenge->server_version     = 50099;
+ 	challenge->charset            = 0x08; /* latin1 */
+-	challenge->capabilities       = CLIENT_PROTOCOL_41 | CLIENT_SECURE_CONNECTION | CLIENT_LONG_PASSWORD;
++	challenge->capabilities       = CLIENT_PROTOCOL_41 | CLIENT_SECURE_CONNECTION;
+ 	challenge->server_status      = SERVER_STATUS_AUTOCOMMIT;
+ 	challenge->thread_id          = 1;
+ 
+diff -ru mysql-proxy-0.8.5.orig/src/network-mysqld-packet.c mysql-proxy-0.8.5/src/network-mysqld-packet.c
+--- mysql-proxy-0.8.5.orig/src/network-mysqld-packet.c	2014-08-19 01:18:26.000000000 -0700
++++ mysql-proxy-0.8.5/src/network-mysqld-packet.c	2018-04-05 22:00:29.112079765 -0700
+@@ -97,7 +97,7 @@
+ 			err = err || network_mysqld_proto_get_ok_packet(packet, ok_packet);
+ 
+ 			if (!err) {
+-				if (ok_packet->server_status & SERVER_MORE_RESULTS_EXISTS) {
++				if (ok_packet->server_status & SERVER_MORE_RESULTS_EXIST) {
+ 			
+ 				} else {
+ 					is_finished = 1;
+@@ -167,7 +167,7 @@
+ 
+ 				if (!err) {
+ #if MYSQL_VERSION_ID >= 50000
+-					/* 5.5 may send a SERVER_MORE_RESULTS_EXISTS as part of the first 
++					/* 5.5 may send a SERVER_MORE_RESULTS_EXIST as part of the first 
+ 					 * EOF together with SERVER_STATUS_CURSOR_EXISTS. In that case,
+ 					 * we aren't finished. (#61998)
+ 					 *
+@@ -180,7 +180,7 @@
+ 					 */
+ 					if (use_binary_row_data &&
+ 					    eof_packet->server_status & SERVER_STATUS_CURSOR_EXISTS &&
+-					    !(eof_packet->server_status & SERVER_MORE_RESULTS_EXISTS)) {
++					    !(eof_packet->server_status & SERVER_MORE_RESULTS_EXIST)) {
+ 						is_finished = 1;
+ 					} else {
+ 						query->state = PARSE_COM_QUERY_RESULT;
+@@ -234,7 +234,7 @@
+ 					}
+ 					query->warning_count = eof_packet->warnings;
+ 
+-					if (query->server_status & SERVER_MORE_RESULTS_EXISTS) {
++					if (query->server_status & SERVER_MORE_RESULTS_EXIST) {
+ 						query->state = PARSE_COM_QUERY_INIT;
+ 					} else {
+ 						is_finished = 1;


### PR DESCRIPTION
Add patch for updated protocol flags in recent mysql/mariadb:

- Spelling of SERVER_MORE_RESULTS_EXISTS -> SERVER_MORE_RESULTS_EXIST
- CLIENT_LONG_PASSWORD is assumed on, and should no longer be passed